### PR TITLE
Strip HTML from page titles

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"> 
-      <title>{% if page.title %} {{ page.title | replace:'<br />','' }} | {% endif %} Stop Watching Us</title> 
+      <title>{% if page.title %} {{ page.title | strip_html }} | {% endif %} Stop Watching Us</title> 
       <meta name="description" content="On October 26th, people from all walks of life will descend on Washington, DC to call for an end to mass NSA surveillance. Will you be there?"> 
       <meta name="viewport" content="width=device-width"> 
       <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.0/css/bootstrap.min.css"> 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"> 
-      <title>{% if page.title %} {{ page.title }} | {% endif %} Stop Watching Us</title> 
+      <title>{% if page.title %} {{ page.title | replace:'<br />','' }} | {% endif %} Stop Watching Us</title> 
       <meta name="description" content="On October 26th, people from all walks of life will descend on Washington, DC to call for an end to mass NSA surveillance. Will you be there?"> 
       <meta name="viewport" content="width=device-width"> 
       <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.0.0/css/bootstrap.min.css"> 


### PR DESCRIPTION
In the project megaphone you use a line break to make the title look good ( good call. ) but that leaks i not the webpage's title element which you don't want. This fixes that,
